### PR TITLE
Disable Sidekiq for memory purposes

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-sidekiq: bundle exec sidekiq -C config/sidekiq.yml
+# sidekiq: bundle exec sidekiq -C config/sidekiq.yml


### PR DESCRIPTION
Until we implement something to limit the amount of workers that are being spun up. 
